### PR TITLE
Sped up animation, added easing function, and cleaned code

### DIFF
--- a/src/components/TheCountdown.vue
+++ b/src/components/TheCountdown.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="outer-container gradient" ref="container">
+  <div class="outer-container countdown" ref="container">
     <h1>
       {{ format(tweened_month.toFixed(0)) }} /
       {{ format(tweened_day.toFixed(0)) }} /
-      {{ tweened_year.toFixed(0) }}
+      {{ format(tweened_year.toFixed(0), 4) }}
     </h1>
     <Transition>
       <header v-show="containerIsVisible">
@@ -47,42 +47,36 @@ export default {
       date_year: null,
       tweened_month: 0,
       tweened_day: 0,
-      tweened_year: 2000,
+      tweened_year: 0,
     };
   },
   watch: {
     date_year(n) {
-      gsap.to(this, { duration: 5, tweened_year: Number(n) || 0 });
+      gsap.to(this, { duration: 4.5, tweened_year: Number(n) || 0, ease: "expo" });
     },
     date_day(n) {
-      gsap.to(this, { duration: 5, tweened_day: Number(n) || 0 });
+      gsap.to(this, { duration: 4.5, tweened_day: Number(n) || 0, ease: "expo" });
     },
     date_month(n) {
-      gsap.to(this, { duration: 5, tweened_month: Number(n) || 0 });
+      gsap.to(this, { duration: 4.5, tweened_month: Number(n) || 0, ease: "expo"});
     },
   },
   methods: {
     setTime() {
       var timeLeft = new Date(`${this.date.year}/${this.date.month}/${this.date.day} 12:00:00`) - new Date();
 
-      var daysLeft = timeLeft / 8.64e7;
-      var hoursLeft = (timeLeft / 3.6e6) % 24;
-      var minLeft = (timeLeft / 60000) % 60;
-      var secsLeft = (timeLeft / 1000) % 60;
-      var millisecondsLeft = (secsLeft % 1) * 1000;
-
-      this.milliseconds = millisecondsLeft;
-      this.seconds = secsLeft;
-      this.minutes = minLeft;
-      this.hours = hoursLeft;
-      this.days = daysLeft;
+      this.days = timeLeft / 8.64e7;
+      this.hours = (timeLeft / 3.6e6) % 24;
+      this.minutes = (timeLeft / 60000) % 60;
+      this.seconds = (timeLeft / 1000) % 60;
+      this.milliseconds = (this.seconds % 1) * 1000;
     },
-    format(number) {
+    format(number, digitsToPad = 2) {
       if (number < 0) {
         number = 0;
       }
       var s = "" + Math.floor(number);
-      return s.padStart(2, "0");
+      return s.padStart(digitsToPad, "0");
     },
   },
   mounted() {
@@ -93,7 +87,7 @@ export default {
       this.date_day = this.date.day;
       this.date_month = this.date.month;
       this.date_year = this.date.year;
-    }, 2000);
+    }, 500);
   },
 };
 </script>
@@ -114,9 +108,9 @@ export default {
   overflow: hidden;
 }
 
-.gradient {
+.countdown {
   animation-name: fade-in;
-  animation-duration: 10s;
+  animation-duration: 5s;
   animation-iteration-count: 1;
   animation-timing-function: linear;
   width: 100%;
@@ -138,7 +132,7 @@ h3 {
   font-size: 3em;
   animation-name: fade-in;
   opacity: 0;
-  animation-delay: 2s;
+  animation-delay: 2.5s;
   animation-duration: 2.5s;
   animation-iteration-count: 1;
   animation-timing-function: linear;
@@ -158,7 +152,6 @@ h3 {
 .v-enter-active,
 .v-leave-active {
   transition: opacity 5s linear;
-  transition-delay: 0.5s;
 }
 
 .v-enter-from,


### PR DESCRIPTION
1. Sped up the animation since 10 seconds felt like way too long.
2. Cleaned the code a little bit (removed unnecessary variables)
3. Added an easing function for the date reveal so that it slowed down near the end. I chose to use the `expo` easing function but there are [many options](https://gsap.com/docs/v3/Eases/). 
4. Changed the initial date of the date reveal to 00/00/0000 instead of 00/00/2000.
  - Changed the `format` function to allow for padding up to an arbitrary number of digits so that the date always has four digits.
  
  All animations should complete in five seconds now, including pre-animation delays.